### PR TITLE
Fix issue 'Index out of range #140'

### DIFF
--- a/cpp/ast.py
+++ b/cpp/ast.py
@@ -1095,6 +1095,8 @@ class ASTBuilder(object):
                     token = self._get_next_token()
                     continue
                 member, token = self.get_name()
+                if not member:
+                    continue
                 member = member[0]
                 if token.name == '(' or token.name == '{':
                     end = '}' if token.name == '{' else ')'


### PR DESCRIPTION
get_name() can return an empty list, see comment https://github.com/myint/cppclean/issues/140#issuecomment-520799414